### PR TITLE
Added gmp extension

### DIFF
--- a/layers/gmp/Dockerfile
+++ b/layers/gmp/Dockerfile
@@ -1,0 +1,34 @@
+ARG PHP_VERSION
+FROM bref/build-php-$PHP_VERSION AS ext
+
+# Fix library path
+ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
+
+# Install packages
+RUN yum install -y gmp-devel
+
+# Build PHP extension
+WORKDIR /tmp/build/php/ext/gmp
+RUN phpize && \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --prefix=${INSTALL_DIR} \
+        --enable-option-checking=fatal
+    
+RUN make -j $(nproc) install
+RUN cp /opt/bref/lib/php/extensions/no-debug-zts-*/gmp.so /tmp/gmp.so
+
+# Build the final image from the lambci image that is close to the production environment
+FROM lambci/lambda:provided
+
+# Copy things we installed to the final image
+COPY --from=ext /usr/include/gmp-mparam-x86_64.h /opt/bref/include/gmp-mparam-x86_64.h
+COPY --from=ext /usr/include/gmp-mparam.h /opt/bref/include/gmp-mparam.h
+COPY --from=ext /usr/include/gmp-x86_64.h /opt/bref/include/gmp-x86_64.h
+COPY --from=ext /usr/include/gmp.h /opt/bref/include/gmp.h
+COPY --from=ext /usr/include/gmpxx.h /opt/bref/include/gmpxx.h
+
+COPY --from=ext /usr/lib64/libgmp.so /opt/bref/lib64/libgmp.so
+COPY --from=ext /usr/lib64/libgmpxx.so /opt/bref/lib64/libgmpxx.so
+
+COPY --from=ext /tmp/gmp.so /opt/bref-extra/gmp.so


### PR DESCRIPTION
I needed the gmp extension to be able to verify RS-256 JWT tokens issued by Cognito using the web-token/jwt-signature-algorithm-rsa library.

It is probably easier to add the gmp extension to the default bref layer, but for now I've created this extra extension layer. I hope this is the correct way of doing things. 

I've only been able to test the layer with Docker so far, which worked great. I created a Dockerfile with the following contents:

```
FROM bref/php-74-fpm-dev

COPY --from=bref/layers/gmp-php-74:latest /opt/bref/include/gmp* /opt/bref/include/
COPY --from=bref/layers/gmp-php-74:latest /opt/bref/lib64/*gmp* /opt/bref/lib64/
COPY --from=bref/layers/gmp-php-74:latest /opt/bref-extra/gmp* /opt/bref-extra/
```

I was hoping there was an easier way to copy all changes from the layer Docker image, but I haven't found a better solution yet.