### PR TITLE
Add imagick with webp support and binding to newer versions of ImageMagick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - LAYER=amqp PHP="72 73 74"
   - LAYER=blackfire PHP="72 73 74"
   - LAYER=gmp PHP="72 73 74"
+  - LAYER=imagick PHP="72 73 74"
   - LAYER=mailparse PHP="72 73 74"
   - LAYER=pcov PHP="72 73 74"
   - LAYER=pgsql PHP="72 73 74"

--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ extension=/opt/bref-extra/amqp.so
 Note that the "Memcached" layer provides both extension for [Memcache](https://pecl.php.net/package/memcache) and [Memcached](https://pecl.php.net/package/memcached). 
 
 Note that you cannot use both the built-in imagick extension and imagick extension from this package.
-This version of imagick is built against newer version of ImageMagick than the built-in one and provides webp support.
+This version of imagick is built against newer version of ImageMagick than the built-in one and provides heic and webp support.
 
 ### Blackfire installation
 

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ extension=/opt/bref-extra/amqp.so
 | AMQP | `${bref:extra.amqp-php-74}` | `extension=/opt/bref-extra/amqp.so` |
 | Blackfire | `${bref:extra.blackfire-php-74}` | `extension=/opt/bref-extra/blackfire.so` |
 | GMP | `${bref:extra.gmp-php-74}` | `extension=/opt/bref-extra/gmp.so` |
+| Imagick | `${bref:extra.imagick-php-74}` | `extension=/opt/bref-extra/imagick.so` |
 | Mailparse | `${bref:extra.mailparse-php-74}` | `extension=/opt/bref-extra/mailparse.so` |
 | Memcache | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcache.so` |
 | Memcached | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcached.so` |
@@ -54,6 +55,9 @@ extension=/opt/bref-extra/amqp.so
 | Xdebug | `${bref:extra.xdebug-php-74}` | `zend_extension=/opt/bref-extra/xdebug.so` |
 
 Note that the "Memcached" layer provides both extension for [Memcache](https://pecl.php.net/package/memcache) and [Memcached](https://pecl.php.net/package/memcached). 
+
+Note that you cannot use both the built-in imagick extension and imagick extension from this package.
+This version of imagick is built against newer version of ImageMagick than the built-in one and provides webp support.
 
 ### Blackfire installation
 

--- a/layers/imagick/Dockerfile
+++ b/layers/imagick/Dockerfile
@@ -1,0 +1,36 @@
+ARG PHP_VERSION
+FROM bref/build-php-$PHP_VERSION as ext
+
+# Prepare environment
+ENV IMAGICK_BUILD_DIR=${BUILD_DIR}/imagick
+RUN mkdir -p ${IMAGICK_BUILD_DIR}
+WORKDIR ${IMAGICK_BUILD_DIR}
+RUN LD_LIBRARY_PATH= yum -y install libwebp-devel
+
+# Compile the ImageMagick library
+RUN curl https://imagemagick.org/download/ImageMagick-6.9.11-7.tar.gz > ImageMagick.tar.gz
+RUN tar xzf ImageMagick.tar.gz
+WORKDIR ${IMAGICK_BUILD_DIR}/ImageMagick-6.9.11-7
+RUN ./configure --prefix ${INSTALL_DIR} --exec-prefix ${INSTALL_DIR} --with-webp
+RUN make -j $(nproc)
+RUN make install
+
+# Compile the php imagick extension
+WORKDIR ${IMAGICK_BUILD_DIR}
+RUN pecl download imagick
+RUN tar xzf imagick-3.4.4.tgz
+WORKDIR ${IMAGICK_BUILD_DIR}/imagick-3.4.4
+RUN phpize
+RUN ./configure --with-imagick=${INSTALL_DIR}
+RUN make -j $(nproc)
+RUN make install
+RUN cp `php-config --extension-dir`/imagick.so /tmp/imagick.so
+
+FROM lambci/lambda:provided
+
+# The libraries needed by the extension
+COPY --from=ext /opt/bref/lib/libMagickWand-6.Q16.so.6.0.0 /opt/bref/lib/libMagickWand-6.Q16.so.6
+COPY --from=ext /opt/bref/lib/libMagickCore-6.Q16.so.6.0.0 /opt/bref/lib/libMagickCore-6.Q16.so.6
+COPY --from=ext /usr/lib64/libwebp.so.4.0.2 /opt/bref/lib/libwebp.so.4
+
+COPY --from=ext /tmp/imagick.so /opt/bref-extra/imagick.so

--- a/layers/imagick/Dockerfile
+++ b/layers/imagick/Dockerfile
@@ -4,14 +4,32 @@ FROM bref/build-php-$PHP_VERSION as ext
 # Prepare environment
 ENV IMAGICK_BUILD_DIR=${BUILD_DIR}/imagick
 RUN mkdir -p ${IMAGICK_BUILD_DIR}
+RUN LD_LIBRARY_PATH= yum -y install libwebp-devel wget
+
+# Compile libde265 (libheif dependency)
 WORKDIR ${IMAGICK_BUILD_DIR}
-RUN LD_LIBRARY_PATH= yum -y install libwebp-devel
+RUN wget https://github.com/strukturag/libde265/releases/download/v1.0.5/libde265-1.0.5.tar.gz -O libde265.tar.gz
+RUN tar xzf libde265.tar.gz
+WORKDIR ${IMAGICK_BUILD_DIR}/libde265-1.0.5
+RUN ./configure --prefix ${INSTALL_DIR} --exec-prefix ${INSTALL_DIR}
+RUN make -j $(nproc)
+RUN make install
+
+# Compile libheif
+WORKDIR ${IMAGICK_BUILD_DIR}
+RUN wget https://github.com/strukturag/libheif/releases/download/v1.6.2/libheif-1.6.2.tar.gz -O libheif.tar.gz
+RUN tar xzf libheif.tar.gz
+WORKDIR ${IMAGICK_BUILD_DIR}/libheif-1.6.2
+RUN ./configure --prefix ${INSTALL_DIR} --exec-prefix ${INSTALL_DIR}
+RUN make -j $(nproc)
+RUN make install
 
 # Compile the ImageMagick library
-RUN curl https://imagemagick.org/download/ImageMagick-6.9.11-7.tar.gz > ImageMagick.tar.gz
+WORKDIR ${IMAGICK_BUILD_DIR}
+RUN wget https://github.com/ImageMagick/ImageMagick6/archive/6.9.11-7.tar.gz -O ImageMagick.tar.gz
 RUN tar xzf ImageMagick.tar.gz
-WORKDIR ${IMAGICK_BUILD_DIR}/ImageMagick-6.9.11-7
-RUN ./configure --prefix ${INSTALL_DIR} --exec-prefix ${INSTALL_DIR} --with-webp
+WORKDIR ${IMAGICK_BUILD_DIR}/ImageMagick6-6.9.11-7
+RUN ./configure --prefix ${INSTALL_DIR} --exec-prefix ${INSTALL_DIR} --with-webp --with-heic --disable-static
 RUN make -j $(nproc)
 RUN make install
 
@@ -28,9 +46,13 @@ RUN cp `php-config --extension-dir`/imagick.so /tmp/imagick.so
 
 FROM lambci/lambda:provided
 
-# The libraries needed by the extension
+# The ImageMagick libraries needed by the extension
 COPY --from=ext /opt/bref/lib/libMagickWand-6.Q16.so.6.0.0 /opt/bref/lib/libMagickWand-6.Q16.so.6
 COPY --from=ext /opt/bref/lib/libMagickCore-6.Q16.so.6.0.0 /opt/bref/lib/libMagickCore-6.Q16.so.6
+
+# ImageMagick dependencies
 COPY --from=ext /usr/lib64/libwebp.so.4.0.2 /opt/bref/lib/libwebp.so.4
+COPY --from=ext /opt/bref/lib/libde265.so.0.0.12 /opt/bref/lib/libde265.so.0
+COPY --from=ext /opt/bref/lib/libheif.so.1.6.2 /opt/bref/lib/libheif.so.1
 
 COPY --from=ext /tmp/imagick.so /opt/bref-extra/imagick.so


### PR DESCRIPTION
I tested it with php 7.2, 7.3 and 7.4.

What I tested:

- image can be outputted in the webp format
- the method `compositeImageGravity()` exists