### PR TITLE
add igbinary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - LAYER=amqp PHP="72 73 74"
   - LAYER=blackfire PHP="72 73 74"
   - LAYER=gmp PHP="72 73 74"
+  - LAYER=igbinary PHP="72 73 74"
   - LAYER=mailparse PHP="72 73 74"
   - LAYER=pcov PHP="72 73 74"
   - LAYER=pgsql PHP="72 73 74"

--- a/Readme.md
+++ b/Readme.md
@@ -46,6 +46,7 @@ extension=/opt/bref-extra/amqp.so
 | AMQP | `${bref:extra.amqp-php-74}` | `extension=/opt/bref-extra/amqp.so` |
 | Blackfire | `${bref:extra.blackfire-php-74}` | `extension=/opt/bref-extra/blackfire.so` |
 | GMP | `${bref:extra.gmp-php-74}` | `extension=/opt/bref-extra/gmp.so` |
+| Igbinary | `${bref:extra.igbinary-php-74}` | `extension=/opt/bref-extra/igbinary.so` |
 | Mailparse | `${bref:extra.mailparse-php-74}` | `extension=/opt/bref-extra/mailparse.so` |
 | Memcache | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcache.so` |
 | Memcached | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcached.so` |

--- a/docs/create_your_own_extension_layer.md
+++ b/docs/create_your_own_extension_layer.md
@@ -88,7 +88,7 @@ $ make docker-images
 If the build goes through, generate zip files of the layers in `export/` directory.
 
 ```bash
-$ make layer
+$ make layers
 ```
 
 Register the zip file generated above to AWS as Lambda Layer. It also able to add from AWS console.

--- a/layers/igbinary/Dockerfile
+++ b/layers/igbinary/Dockerfile
@@ -1,0 +1,11 @@
+ARG PHP_VERSION
+FROM bref/build-php-$PHP_VERSION AS ext
+
+RUN pecl install igbinary
+RUN cp `php-config --extension-dir`/igbinary.so /tmp/igbinary.so
+
+# Build the final image from the lambci image that is close to the production environment
+FROM lambci/lambda:provided
+
+# Copy things we installed to the final image
+COPY --from=ext /tmp/igbinary.so /opt/bref-extra/igbinary.so


### PR DESCRIPTION
added igbinary as drop in replacement for the standard php serializer.

Tested with bref php 7.3 layer and bref php 7.4 layer on lambda. Works as expected.