### PR TITLE
Exclude "prepare-release" branch from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: minimal
 
-# blocklist
 branches:
   except:
   - /^blackfire-.*$/
+  - prepare-release
 
 notifications:
   email:


### PR DESCRIPTION
We will still build it because it is a PR. 