### PR TITLE
chore: use scratch as final image

### DIFF
--- a/docs/create_your_own_extension_layer.md
+++ b/docs/create_your_own_extension_layer.md
@@ -1,6 +1,6 @@
 # How to build new layer
 
-To create your own extension layer, compile the extension and any required libraries 
+To create your own extension layer, compile the extension and any required libraries
 with Docker. This guide uses pgsql extension as an example.
 
 First create new extension directory in `layers/` and move there.
@@ -19,24 +19,24 @@ FROM bref/build-php-$PHP_VERSION AS ext
 # Add commands to build PHP extensions here.
 #
 
-# Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+# Build the final image from the scratch image that contain files you want to export
+FROM scratch
 
 #
 # Add commands to copy files that required for final image.
 #
 ```
 
-The environment variable `PHP_VERSION` is passed from the Makefile as an argument 
-to docker build. It may have values like: `72`, `73`, `74`. A docker image is created 
-for each PHP_VERSION. If the build procedure of your extension differs for each version, 
+The environment variable `PHP_VERSION` is passed from the Makefile as an argument
+to docker build. It may have values like: `72`, `73`, `74`. A docker image is created
+for each PHP_VERSION. If the build procedure of your extension differs for each version,
 you may use this variable to switch processing in Dockerfile.
 
 There are some other env variables available,`PHP_BUILD_DIR` is `/tmp/build/php`, `INSTALL_DIR` is `/opt/bref`.
 
 ### Building your extension
 
-Then you need to add two parts of Dockerfile, the following snippets are examples 
+Then you need to add two parts of Dockerfile, the following snippets are examples
 of build and copy parts respectively.
 
 ```Dockerfile
@@ -49,10 +49,10 @@ RUN make -j `nproc` && make install
 RUN cp `php-config --extension-dir`/pgsql.so /tmp/pgsql.so
 ```
 
-You may need to: 
- - download the source code, 
- - install the libraries required for compilation, 
- - perform pecl install, 
+You may need to:
+ - download the source code,
+ - install the libraries required for compilation,
+ - perform pecl install,
  - etc.
 
 The Dockerfiles for [these](../layers) extensions could be very helpful.
@@ -60,8 +60,8 @@ The Dockerfiles for [these](../layers) extensions could be very helpful.
 ### Copy files
 
 
-The extension layer consists of a zip archive of files that overlay the PHP layer, 
-so copy the files and create the layer file structure here. Extension and all related 
+The extension layer consists of a zip archive of files that overlay the PHP layer,
+so copy the files and create the layer file structure here. Extension and all related
 files that need to be installed should be placed `/opt` directory in the final image.
 Because only `/opt` directory is allowed to put things in Lambda custom runtime
 environment.
@@ -70,9 +70,9 @@ environment.
 COPY --from=ext /tmp/pgsql.so /opt/bref-extra/pgsql.so
 ```
 
-### Making a layer 
+### Making a layer
 
-It might be good to build extension step-by-step and create Dockerfile from command 
+It might be good to build extension step-by-step and create Dockerfile from command
 history instead of immediately building from Dockerfile.
 
 ```bash
@@ -111,7 +111,7 @@ $ vendor/bin/bref init
   [0] PHP function
   [1] HTTP application
   [2] Console application
- > 1                          
+ > 1
 ## Select suitable for check your extension.
 ```
 

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -21,7 +21,7 @@ RUN pecl install amqp
 RUN cp /opt/bref/lib/php/extensions/no-debug-zts-*/amqp.so /tmp/amqp.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /opt/bref/include/amqp.h /opt/bref/include/amqp.h

--- a/layers/blackfire/Dockerfile
+++ b/layers/blackfire/Dockerfile
@@ -10,7 +10,7 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")-zts \
 
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/blackfire.so /opt/bref-extra/blackfire.so

--- a/layers/cassandra/Dockerfile
+++ b/layers/cassandra/Dockerfile
@@ -12,7 +12,7 @@ ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
 
 WORKDIR /tmp
 
-RUN yum install -y automake cmake gcc gcc-c++ git libtool openssl-devel wget gmp gmp-devel boost php-devel pcre-devel 
+RUN yum install -y automake cmake gcc gcc-c++ git libtool openssl-devel wget gmp gmp-devel boost php-devel pcre-devel
 
 # Install dependencies
 RUN curl -o libuv.rpm https://downloads.datastax.com/cpp-driver/centos/7/dependencies/libuv/v$LIBUV_VERSION/libuv-$LIBUV_VERSION-1.el7.x86_64.rpm
@@ -31,7 +31,7 @@ RUN cd /tmp && \
 RUN cp `php-config --extension-dir`/cassandra.so /tmp/cassandra.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 
 # php extension binary

--- a/layers/ds/Dockerfile
+++ b/layers/ds/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install ds
 RUN cp `php-config --extension-dir`/ds.so /tmp/ds.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/ds.so /opt/bref-extra/ds.so

--- a/layers/gmp/Dockerfile
+++ b/layers/gmp/Dockerfile
@@ -14,12 +14,12 @@ RUN phpize && \
         --build=x86_64-pc-linux-gnu \
         --prefix=${INSTALL_DIR} \
         --enable-option-checking=fatal
-    
+
 RUN make -j $(nproc) install
 RUN cp /opt/bref/lib/php/extensions/no-debug-zts-*/gmp.so /tmp/gmp.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /usr/include/gmp-mparam-x86_64.h /opt/bref/include/gmp-mparam-x86_64.h

--- a/layers/grpc/Dockerfile
+++ b/layers/grpc/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install grpc > /dev/null
 RUN cp `php-config --extension-dir`/grpc.so /tmp/grpc.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/grpc.so /opt/bref-extra/grpc.so

--- a/layers/igbinary/Dockerfile
+++ b/layers/igbinary/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install igbinary
 RUN cp `php-config --extension-dir`/igbinary.so /tmp/igbinary.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/igbinary.so /opt/bref-extra/igbinary.so

--- a/layers/imagick/Dockerfile
+++ b/layers/imagick/Dockerfile
@@ -44,7 +44,7 @@ RUN make -j $(nproc)
 RUN make install
 RUN cp `php-config --extension-dir`/imagick.so /tmp/imagick.so
 
-FROM lambci/lambda:provided
+FROM scratch
 
 # The ImageMagick libraries needed by the extension
 COPY --from=ext /opt/bref/lib/libMagickWand-6.Q16.so.6.0.0 /opt/bref/lib/libMagickWand-6.Q16.so.6

--- a/layers/mailparse/Dockerfile
+++ b/layers/mailparse/Dockerfile
@@ -8,7 +8,7 @@ RUN pecl install mailparse
 RUN cp `php-config --extension-dir`/mailparse.so /tmp/mailparse.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/mailparse.so /opt/bref-extra/mailparse.so

--- a/layers/memcached/Dockerfile
+++ b/layers/memcached/Dockerfile
@@ -36,7 +36,7 @@ RUN pecl install --onlyreqdeps --nobuild memcached && \
 RUN cp /opt/bref/lib/php/extensions/no-debug-zts-*/memcached.so /tmp/memcached.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /opt/bref/include/libmemcached/ /opt/bref/include/libmemcached/

--- a/layers/mongodb/Dockerfile
+++ b/layers/mongodb/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install --force mongodb
 RUN cp `php-config --extension-dir`/mongodb.so /tmp/mongodb.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/mongodb.so /opt/bref-extra/mongodb.so

--- a/layers/odbc-snowflake/Dockerfile
+++ b/layers/odbc-snowflake/Dockerfile
@@ -20,7 +20,7 @@ RUN curl https://sfc-repo.snowflakecomputing.com/odbc/linux/2.21.3/snowflake_lin
 RUN sed -i 's#/path/to/your/#/opt/snowflake_odbc/lib/#g' /tmp/snowflake_odbc/conf/*
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 COPY --from=ext /usr/lib64/libodb* /opt/bref/lib64/
 COPY --from=ext /tmp/snowflake_odbc/ /opt/snowflake_odbc/

--- a/layers/pcov/Dockerfile
+++ b/layers/pcov/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install pcov
 RUN cp `php-config --extension-dir`/pcov.so /tmp/pcov.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/pcov.so /opt/bref-extra/pcov.so

--- a/layers/pgsql/Dockerfile
+++ b/layers/pgsql/Dockerfile
@@ -9,7 +9,7 @@ RUN make -j `nproc` && make install
 RUN cp `php-config --extension-dir`/pgsql.so /tmp/pgsql.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/pgsql.so /opt/bref-extra/pgsql.so

--- a/layers/redis/Dockerfile
+++ b/layers/redis/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install --force redis
 RUN cp `php-config --extension-dir`/redis.so /tmp/redis.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/redis.so /opt/bref-extra/redis.so

--- a/layers/scrypt/Dockerfile
+++ b/layers/scrypt/Dockerfile
@@ -4,6 +4,6 @@ FROM bref/build-php-$PHP_VERSION AS ext
 RUN pecl install scrypt
 RUN cp `php-config --extension-dir`/scrypt.so /tmp/scrypt.so
 
-FROM lambci/lambda:provided
+FROM scratch
 
 COPY --from=ext /tmp/scrypt.so /opt/bref-extra/scrypt.so

--- a/layers/uuid/Dockerfile
+++ b/layers/uuid/Dockerfile
@@ -9,7 +9,7 @@ RUN pecl install uuid
 RUN cp `php-config --extension-dir`/uuid.so /tmp/uuid.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/uuid.so /opt/bref-extra/uuid.so

--- a/layers/xdebug/Dockerfile
+++ b/layers/xdebug/Dockerfile
@@ -5,7 +5,7 @@ RUN pecl install xdebug
 RUN cp `php-config --extension-dir`/xdebug.so /tmp/xdebug.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM scratch
 
 # Copy things we installed to the final image
 COPY --from=ext /tmp/xdebug.so /opt/bref-extra/xdebug.so

--- a/layers/yaml/Dockerfile
+++ b/layers/yaml/Dockerfile
@@ -22,7 +22,7 @@ RUN set -xe; \
 RUN pecl install yaml
 RUN cp /opt/bref/lib/php/extensions/no-debug-zts-*/yaml.so /tmp/yaml.so
 
-FROM lambci/lambda:provided
+FROM scratch
 
 COPY --from=ext /opt/bref/lib/libyaml-0.so.2 /opt/bref/lib64/libyaml-0.so.2
 COPY --from=ext /opt/bref/lib/libyaml-0.so.2.0.9 /opt/bref/lib64/libyaml-0.so.2.0.9


### PR DESCRIPTION
So, once this one gets merged you can definitely compose extensions more easily.

### BEFORE

As extra extensions docker images are built from `lambci/lambda:provided`, they are pretty big for nothing...
![image](https://user-images.githubusercontent.com/54712/93796585-55254f80-fc3b-11ea-98ee-41b396112613.png)

And you possibly have to know more in details if the image requires to copy only resulting extension or also other libraries (lib or lib64?).

```Dockerfile
FROM bref/php-74-fpm-dev

COPY --from=bref/extra-redis-php-74 /opt/bref-extra /opt/bref-extra
COPY --from=bref/extra-imagick-php-74 /opt/bref/lib /opt/bref/lib
COPY --from=bref/extra-imagick-php-74 /opt/bref-extra /opt/bref-extra
```

### AFTER

Lightweight extra extension docker image & no more questions.

```Dockerfile
FROM bref/php-74-fpm-dev

COPY --from=bref/extra-redis-php-74 /opt /opt
COPY --from=bref/extra-imagick-php-74 /opt /opt
```