### PR TITLE
Copy output with docker cp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ layers: docker-images
 			echo "### Exporting $${dir} PHP$${php_version}"; \
 			echo "###"; \
 			cd ${PWD} ; rm -rf export/tmp/${layer} || true ; cd export/tmp ; \
-			CID=$$(docker create --entrypoint=/bin/bash bref/$${dir}-php-$${php_version}) ; \
+			CID=$$(docker create --entrypoint=scratch bref/$${dir}-php-$${php_version}) ; \
 			docker cp $${CID}:/opt . ; \
 			docker rm $${CID} ; \
 			cd ./opt ; \
@@ -83,5 +83,4 @@ publish-docker-images: docker-images
 			echo ""; \
 		done \
 	done
-
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker-images:
 layers: docker-images
 	PWD=pwd
 	rm -rf export/layer-${layer}.zip || true
-	mkdir export/tmp
+	mkdir -p export/tmp
 	set -e; \
 	for dir in layers/${layer}; do \
 		for php_version in $(php_versions); do \
@@ -45,8 +45,11 @@ layers: docker-images
 			echo "### Exporting $${dir} PHP$${php_version}"; \
 			echo "###"; \
 			cd ${PWD} ; rm -rf export/tmp/${layer} || true ; cd export/tmp ; \
-			docker run --entrypoint "tar" bref/$${dir}-php-$${php_version} -ch -C /opt . | tar -x ; \
-			zip --quiet -X --recurse-paths ../`echo "$${dir}-php-$${php_version}" | sed -e "s/layers\//layer-/g"`.zip . ; \
+			CID=$$(docker create --entrypoint=/bin/bash bref/$${dir}-php-$${php_version}) ; \
+			docker cp $${CID}:/opt . ; \
+			docker rm $${CID} ; \
+			cd ./opt ; \
+			zip --quiet -X --recurse-paths ../../`echo "$${dir}-php-$${php_version}" | sed -e "s/layers\//layer-/g"`.zip . ; \
 			echo ""; \
 		done \
 	done


### PR DESCRIPTION
This will fix #80. 

We cannot use `tar` anymore since it is not available in `scratch`. 