### PR TITLE
Make sure we conflict with versions before bref 1.0 beta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "conflict": {
-        "bref/bref": "<0.6.0"
+        "bref/bref": "<0.100.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
If Bref decides to release 0.6.0, we should make sure one cannot install the next version of bref extensions. 

From this point on, bref extension is only for Bref 1.0-beta1 and above. 
