### PR TITLE
Remove "parallel"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -209,9 +209,6 @@ git push
 
 #### Config
 
-We build the docker layers in parallel if the GNU `parallel` command is available.
-To make sure to build docker images in sequence run `make publish parallel=false`
-
 You can also build only one specific layer by providing `layer=blackfire` to `make`.
 Same thing for some specific version(s) of php by providing `php_versions="73 74"` to `make`.
 You can invoke both ways:


### PR DESCRIPTION
This will not make the build run much faster on CI since the only thing we run in parallel is PHP versions. It also hides the output while running... 
So I prefer to make the automation a little bit less complicated by removing this. 