### PR TITLE
Remove checksums.json

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@ tests/                       export-ignore
 .phpcs.xml.dist              export-ignore
 .prettyci.composer.json      export-ignore
 bref-extra                   export-ignore
-checksums.json               export-ignore
 config.json                  export-ignore
 Makefile                     export-ignore
 new-docker-tags.php          export-ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,8 @@ jobs:
           git config --local user.email "github-bot@bref.sh"
           git config --local user.name "Bref Bot"
 
-          git add checksums.json layers.json
-          git commit -m "Updated checksums.json and layers.json"
+          git add layers.json
+          git commit -m "Updated layers.json"
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 100
 
+        # Only find layers that have changed since last tag
       - id: find-layers
-        run: echo "::set-output name=list::$(ls layers | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=list::$(git diff --name-only HEAD $(git describe --tags --abbrev=0) | grep layers/ | cut -d / -f 2  | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
 
     outputs:
       # Make the outputs accessible outside this job

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 100
 
         # Only find layers that have changed since last tag
       - id: find-layers
-        run: echo "::set-output name=list::$(git diff --name-only HEAD $(git describe --tags --abbrev=0) | grep layers/ | cut -d / -f 2  | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
+        run: |
+          git fetch --prune --unshallow
+          echo "::set-output name=list::$(git diff --name-only HEAD $(git describe --tags --abbrev=0) | grep layers/ | cut -d / -f 2  | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
 
     outputs:
       # Make the outputs accessible outside this job

--- a/Readme.md
+++ b/Readme.md
@@ -192,8 +192,7 @@ layer=imagick php_versions=74 make test
 #### Use Github actions
 
 Prepare the changelog with some release notes. Then push your changes to `prepare-release` branch.
-The Github Action will build an publish layers and then commit the `checksums.json`
-and `layers.json` to your PR.
+The Github Action will build an publish layers and then commit the `layers.json` to your PR.
 
 Now you will just merge and create a tag.
 
@@ -202,7 +201,7 @@ Now you will just merge and create a tag.
 ```
 export AWS_PROFILE=my_profile
 make publish
-git add checksums.json layers.json
+git add layers.json
 git commit -m "New version of layers"
 git push
 ```

--- a/bref-extra
+++ b/bref-extra
@@ -3,7 +3,7 @@
 require __DIR__.'/vendor/autoload.php';
 
 $app = new Bref\Extra\Application();
-$app->command('publish', \Bref\Extra\Command\PublishCommand::class)->descriptions('Publish new layers. Create checksums.json');
+$app->command('publish', \Bref\Extra\Command\PublishCommand::class)->descriptions('Publish new layers.');
 $app->command('list', \Bref\Extra\Command\ListCommand::class)->descriptions('Create layer.json');
 $app->command('help', \Bref\Extra\Command\HelpCommand::class)->descriptions('Prints some help texts.');
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -25,7 +25,7 @@ class Application extends \Silly\Edition\PhpDi\Application
     {
         $builder = new ContainerBuilder;
         $projectDir = dirname(__DIR__);
-        $localLayers = array_keys(json_decode(file_get_contents($projectDir . '/checksums.json'), true));
+        $localLayers = array_keys(json_decode(file_get_contents($projectDir . '/layers.json'), true));
 
         $builder->addDefinitions([
             'project_dir' => $projectDir,

--- a/src/Command/PublishCommand.php
+++ b/src/Command/PublishCommand.php
@@ -29,10 +29,6 @@ class PublishCommand
 
     public function __invoke(OutputInterface $output): int
     {
-        $checksums = json_decode(file_get_contents($this->projectDir . '/checksums.json'), true);
-        $discoveredChecksums = [];
-
-        $sameChecksumCount = 0;
         $layers = [];
         $finder = new Finder;
         $finder->in($this->projectDir . '/export')->name('layer-*');
@@ -40,14 +36,7 @@ class PublishCommand
             /** @var \SplFileInfo $file */
             $layerFile = $file->getRealPath();
             $layerName = substr($file->getFilenameWithoutExtension(), 6);
-            $md5 = md5_file($layerFile);
-            if ($md5 !== ($checksums[$layerName] ?? '')) {
-                // This layer is new.
-                $discoveredChecksums[$layerName] = $md5;
-                $layers[$layerName] = $layerFile;
-            } else {
-                $sameChecksumCount++;
-            }
+            $layers[$layerName] = $layerFile;
         }
 
         ksort($layers);
@@ -69,15 +58,9 @@ class PublishCommand
             exit(1);
         }
 
-        $checksums = array_merge($checksums, $discoveredChecksums);
-        ksort($checksums);
-        // Dump checksums
-        file_put_contents($this->projectDir . '/checksums.json', json_encode($checksums, \JSON_PRETTY_PRINT));
-
         $output->writeln('');
         $output->writeln('');
         $output->writeln('Done');
-        $output->writeln('Remember to commit and push changes to ./checksums.json');
 
         return 0;
     }


### PR DESCRIPTION
This will fix #140. 

The idea was that we only should update layers that have changes, ie different checksums. But the checksums are always different. That is why the checksum check should be removed. 

Instead we look at the changed layers since last commit and update only those.