### PR TITLE
#218 Fix variable resolution in new Serverless variables system

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ functions:
         handler: bin/console
         layers:
             - ${bref:layer.php-74}
-            - ${bref:extra.amqp-php-74} # <----- Example for AMQP layer
+            - ${bref-extra:amqp-php-74} # <----- Example for AMQP layer
             - ${bref:layer.console}
 ```
 
@@ -40,34 +40,34 @@ functions:
 
 | Name               | Serverless config (php 7.4)           |
 |:-------------------|:--------------------------------------|
-| AMQP               | `${bref:extra.amqp-php-74}`           |
-| Blackfire          | `${bref:extra.blackfire-php-74}`      |
-| Calendar           | `${bref:extra.calendar-php-74}`       |
-| Cassandra          | `${bref:extra.cassandra-php-74}`      |
-| DS                 | `${bref:extra.ds-php-74}`             |
-| GD                 | `${bref:extra.gd-php-74}`             |
-| GMP                | `${bref:extra.gmp-php-74}`            |
-| gRPC               | `${bref:extra.grpc-php-74}`           |
-| Igbinary           | `${bref:extra.igbinary-php-74}`       |
-| Imagick            | `${bref:extra.imagick-php-74}`        |
-| IMAP               | `${bref:extra.imap-php-74}`           |
-| LDAP               | `${bref:extra.ldap-php-74}`           |
-| Mailparse          | `${bref:extra.mailparse-php-74}`      |
-| Memcache           | `${bref:extra.memcache-php-74}`       |
-| Memcached          | `${bref:extra.memcached-php-74}`      |
-| MongoDB            | `${bref:extra.mongodb-php-74}`        |
-| MsgPack            | `${bref:extra.msgpack-php-74}`        |
-| Newrelic           | `${bref:extra.newrelic-php-74}`       |
-| ODBC Snowflake     | `${bref:extra.odbc-snowflake-php-74}` |
-| Pcov               | `${bref:extra.pcov-php-74}`           |
-| PostgreSQL         | `${bref:extra.pgsql-php-74}`          |
-| Redis              | `${bref:extra.redis-php-74}`          |
-| Scrypt             | `${bref:extra.scrypt-php-74}`         |
-| SPX                | `${bref:extra.spx-php-74}`            |
-| Microsoft SQLSRV   | `${bref:extra.sqlsrv-php-74}`         |
-| UUID               | `${bref:extra.uuid-php-74}`           |
-| Xdebug             | `${bref:extra.xdebug-php-74}`         |
-| Yaml               | `${bref:extra.yaml-php-74}`           |
+| AMQP               | `${bref-extra:amqp-php-74}`           |
+| Blackfire          | `${bref-extra:blackfire-php-74}`      |
+| Calendar           | `${bref-extra:calendar-php-74}`       |
+| Cassandra          | `${bref-extra:cassandra-php-74}`      |
+| DS                 | `${bref-extra:ds-php-74}`             |
+| GD                 | `${bref-extra:gd-php-74}`             |
+| GMP                | `${bref-extra:gmp-php-74}`            |
+| gRPC               | `${bref-extra:grpc-php-74}`           |
+| Igbinary           | `${bref-extra:igbinary-php-74}`       |
+| Imagick            | `${bref-extra:imagick-php-74}`        |
+| IMAP               | `${bref-extra:imap-php-74}`           |
+| LDAP               | `${bref-extra:ldap-php-74}`           |
+| Mailparse          | `${bref-extra:mailparse-php-74}`      |
+| Memcache           | `${bref-extra:memcache-php-74}`       |
+| Memcached          | `${bref-extra:memcached-php-74}`      |
+| MongoDB            | `${bref-extra:mongodb-php-74}`        |
+| MsgPack            | `${bref-extra:msgpack-php-74}`        |
+| Newrelic           | `${bref-extra:newrelic-php-74}`       |
+| ODBC Snowflake     | `${bref-extra:odbc-snowflake-php-74}` |
+| Pcov               | `${bref-extra:pcov-php-74}`           |
+| PostgreSQL         | `${bref-extra:pgsql-php-74}`          |
+| Redis              | `${bref-extra:redis-php-74}`          |
+| Scrypt             | `${bref-extra:scrypt-php-74}`         |
+| SPX                | `${bref-extra:spx-php-74}`            |
+| Microsoft SQLSRV   | `${bref-extra:sqlsrv-php-74}`         |
+| UUID               | `${bref-extra:uuid-php-74}`           |
+| Xdebug             | `${bref-extra:xdebug-php-74}`         |
+| Yaml               | `${bref-extra:yaml-php-74}`           |
 
 ### Blackfire installation
 

--- a/docs/create_your_own_extension_layer.md
+++ b/docs/create_your_own_extension_layer.md
@@ -190,13 +190,13 @@ In order to contribute, you should do a little more work.
 
  | Name | Serverless config (php 7.4) | php.ini config |
  | ---- | ----------------------------| -------------- |
- | AMQP | `${bref:extra.amqp-php-74}` | `extension=/opt/bref-extra/amqp.so` |
- | Blackfire | `${bref:extra.blackfire-php-74}` | `extension=/opt/bref-extra/blackfire.so` |
- | GMP | `${bref:extra.gmp-php-74}` | `extension=/opt/bref-extra/gmp.so` |
- | Memcache | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcache.so` |
- | Memcached | `${bref:extra.memcached-php-74}` | `extension=/opt/bref-extra/memcached.so` |
-+| PostgreSQL | `${bref:extra.pgsql-php-74}` | `extension=/opt/bref-extra/pgsql.so` |
- | Xdebug | `${bref:extra.xdebug-php-74}` | `zend_extension=/opt/bref-extra/xdebug.so` |
+ | AMQP | `${bref-extra:amqp-php-74}` | `extension=/opt/bref-extra/amqp.so` |
+ | Blackfire | `${bref-extra:blackfire-php-74}` | `extension=/opt/bref-extra/blackfire.so` |
+ | GMP | `${bref-extra:gmp-php-74}` | `extension=/opt/bref-extra/gmp.so` |
+ | Memcache | `${bref-extra:memcached-php-74}` | `extension=/opt/bref-extra/memcache.so` |
+ | Memcached | `${bref-extra:memcached-php-74}` | `extension=/opt/bref-extra/memcached.so` |
++| PostgreSQL | `${bref-extra:pgsql-php-74}` | `extension=/opt/bref-extra/pgsql.so` |
+ | Xdebug | `${bref-extra:xdebug-php-74}` | `zend_extension=/opt/bref-extra/xdebug.so` |
 
  Note that the "Memcached" layer provides both extension for [Memcache](https://pecl.php.net/package/memcache) and [Memcached](https://pecl.php.net/package/memcached).
 ```

--- a/index.js
+++ b/index.js
@@ -13,13 +13,40 @@ class ServerlessPlugin {
         const filename = path.resolve(__dirname, 'layers.json');
         const layers = JSON.parse(fs.readFileSync(filename));
 
+        // Declare `${bref-extra:xxx}` variables
+        // See https://www.serverless.com/framework/docs/providers/aws/guide/plugins#custom-variable-types
+        this.configurationVariablesSources = {
+            'bref-extra': {
+                async resolve({address, params, resolveConfigurationProperty, options}) {
+                    // `address` and `params` reflect values configured with a variable: ${bref-extra(param1, param2):address}
+
+                    // `options` is CLI options
+                    // `resolveConfigurationProperty` allows to access other configuration properties,
+                    // and guarantees to return a fully resolved form (even if property is configured with variables)
+                    const region = options.region || await resolveConfigurationProperty(['provider', 'region']);
+
+                    if (! (address in layers)) {
+                        throw new Error(`Unknown Bref extra layer named "${address}"`);
+                    }
+                    if (! (region in layers[address])) {
+                        throw new Error(`There is no Bref extra layer named "${address}" in region "${region}"`);
+                    }
+                    const version = layers[address][region];
+                    return {
+                        value: `arn:aws:lambda:${region}:403367587399:layer:${address}:${version}`,
+                    }
+                }
+            }
+        };
+
+        // This is the legacy way of declaring `${bref-extra:xxx}` variables. This has been deprecated in 20210326.
         // Override the variable resolver to declare our own variables
         const delegate = serverless.variables
             .getValueFromSource.bind(serverless.variables);
         serverless.variables.getValueFromSource = (variableString) => {
-            if (variableString.startsWith('bref:extra.')) {
+            if (variableString.startsWith('bref-extra:')) {
                 const region = serverless.getProvider('aws').getRegion();
-                const layerName = variableString.substr('bref:extra.'.length);
+                const layerName = variableString.substr('bref-extra:'.length);
                 if (! (layerName in layers)) {
                     throw `Unknown Bref extra layer named "${layerName}"`;
                 }


### PR DESCRIPTION
Fixes #218 and https://github.com/brefphp/bref/pull/909

The Serverless Framework introduced a new variable system in its latest version. I upgraded Bref recently (https://github.com/brefphp/bref/pull/909) but we need to fix this here too.

The problem is that (from what I tried) the bref-extra plugin cannot register the same variable namespace as Bref: `${bref:...}`.

In this PR I moved to a separate namespace: `${bref-extra:...}`. This is unfortunately a BC break.

Here is an example:

```diff
functions:
    hello:
        handler: index.php
        layers:
            - ${bref:layer.php-74}
-           - ${bref:extra.gd-php-74}
+           - ${bref-extra:gd-php-74}
```