### PR TITLE
Update Redis Dockerfile to fix wrong version compiled

### DIFF
--- a/layers/redis/Dockerfile
+++ b/layers/redis/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION
-FROM bref/build-php-$PHP_VERSION AS ext
+FROM bref/build-php-$PHP_VERSION:1.3.3 AS ext
 
 RUN pecl install --force redis
 RUN cp `php-config --extension-dir`/redis.so /tmp/redis.so

--- a/layers/redis/Dockerfile
+++ b/layers/redis/Dockerfile
@@ -1,5 +1,5 @@
 ARG PHP_VERSION
-FROM bref/build-php-$PHP_VERSION:1.2.13 AS ext
+FROM bref/build-php-$PHP_VERSION AS ext
 
 RUN pecl install --force redis
 RUN cp `php-config --extension-dir`/redis.so /tmp/redis.so

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,6 +2,6 @@ ARG PHP_VERSION
 ARG TARGET_IMAGE
 
 FROM bref/$TARGET_IMAGE AS ext
-FROM bref/php-$PHP_VERSION:1.2.13
+FROM bref/php-$PHP_VERSION:1.3.3
 
 COPY --from=ext /opt /opt


### PR DESCRIPTION
After discovering the Redis extension was failing on PHP startup for 8.1 (https://github.com/brefphp/extra-php-extensions/issues/281), I've now tracked down the extension was being compiled against PHP 8.1 **BETA** 3, rather than RC4. Removing the version on the Docker image should help to keep it in sync going forward with the PHP versions of future Bref releases.