### PR TITLE
Temp fix for deployment issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "mnapoli/silly": "^1.7",
         "mnapoli/silly-php-di": "^1.2",
         "async-aws/core": "^1.7",
-        "symfony/http-client": "^5.2",
+        "symfony/http-client": "5.3.8",
         "async-aws/lambda": "^1.1",
         "bref/logger": "^1.0"
     },


### PR DESCRIPTION
Looking at https://github.com/brefphp/extra-php-extensions/actions/workflows/blackfire.yml it seems the deploy process broke 3 days ago and the only changes to the deploy process in that time were updates to symfony/http-client from 5.3.8 to 5.3.10