### PR TITLE
update odbc snowflake driver and massively reduce layer size

### DIFF
--- a/layers/odbc-snowflake/Dockerfile
+++ b/layers/odbc-snowflake/Dockerfile
@@ -15,8 +15,10 @@ RUN cp /opt/bref/lib/php/extensions/no-debug-non-zts-*/odbc.so /tmp/odbc.so
 RUN echo 'extension=/opt/bref-extra/odbc.so' > /tmp/ext.ini
 
 # https://docs.snowflake.com/en/user-guide/odbc-download.html
-# https://sfc-repo.snowflakecomputing.com/odbc/linux/2.21.3/index.html
-RUN curl https://sfc-repo.snowflakecomputing.com/odbc/linux/2.21.3/snowflake_linux_x8664_odbc-2.21.3.tgz |tar xzv --directory /tmp
+# https://sfc-repo.snowflakecomputing.com/odbc/linux/2.25.0/index.html
+# also: strip more than 100 mb of debug symbols
+RUN curl https://sfc-repo.snowflakecomputing.com/odbc/linux/2.25.0/snowflake_linux_x8664_odbc-2.25.0.tgz |tar xzv --directory /tmp \
+  && strip -g /tmp/snowflake_odbc/lib/libSnowflake.so
 # modify the config files for the new final location in /opt/snowflake_odbc
 RUN sed -i 's#/path/to/your/#/opt/snowflake_odbc/lib/#g' /tmp/snowflake_odbc/conf/*
 

--- a/layers/odbc-snowflake/test.php
+++ b/layers/odbc-snowflake/test.php
@@ -1,5 +1,8 @@
 <?php
 
-// TODO add tests
+if (!function_exists($func = 'odbc_connect')) {
+    echo sprintf('FAIL: Function "%s" does not exist.', $func).PHP_EOL;
+    exit(1);
+}
 
 exit(0);


### PR DESCRIPTION
The odbc-snowflake layer was about 200mb in size.
Most of it was in the libSnowflake.so with 177mb.
I figured that it contains debug flags, that can be stripped.
This reduces the size of that so file to 73 mb.
Still big, but more than 100mb less.