### PR TITLE
Clarify that the redis extension is phpredis

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,7 +68,7 @@ functions:
 | Pcov               | `${bref-extra:pcov-php-81}`           |
 | PostgreSQL         | `${bref-extra:pgsql-php-81}`          |
 | RdKafka            | `${bref-extra:rdkafka-php-81}`        |
-| Redis              | `${bref-extra:redis-php-81}`          |
+| Redis (phpredis)   | `${bref-extra:redis-php-81}`          |
 | Redis-Igbinary     | `${bref-extra:redis-igbinary-php-81}` |
 | Scout APM          | `${bref-extra:scoutapm-php-81}`       |
 | Scrypt             | `${bref-extra:scrypt-php-81}`         |


### PR DESCRIPTION
There are many options to use Redis with PHP ([phpredis](https://github.com/phpredis/phpredis), predis, etc.), it's confusing. I looked at the README and it wasn't clear to me whether it was the phpredis extension (required by a framework), so I thought we might as well clarify.