### PR TITLE
Add explicit versions in the documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -163,8 +163,8 @@ docker-compose.yml
 
 Dockerfile-phpFpm
 ```
-FROM bref/php-82-fpm-dev
-COPY --from=bref/extra-mongodb-php-82 /opt /opt
+FROM bref/php-82-fpm-dev:2
+COPY --from=bref/extra-mongodb-php-82:1 /opt /opt
 ```
 
 ## For contributors and maintainers


### PR DESCRIPTION
To avoid surprises on new major versions that might be incompatible with each other.