### PR TITLE
Fixed broken amqp extension

### DIFF
--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p ${AMQP_BUILD_DIR}
 WORKDIR ${AMQP_BUILD_DIR}
 RUN curl -Ls -o rabbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
 RUN tar xzf rabbitmq-c.tar.gz
-RUN ls
 WORKDIR ${AMQP_BUILD_DIR}/rabbitmq-c-0.13.0
 RUN cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
 RUN cmake --build . --target install
@@ -19,7 +18,7 @@ RUN cmake --build . --target install
 # Compile the php amqp extension
 WORKDIR ${AMQP_BUILD_DIR}
 RUN git clone https://github.com/php-amqp/php-amqp
-WORKDIR ${AMQP_BUILD_DIR}/amqp
+WORKDIR ${AMQP_BUILD_DIR}/php-amqp
 RUN git reset --hard 618e06ad2ef867598831cdd3faadba0dd65be917
 RUN phpize
 RUN ./configure

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -4,7 +4,7 @@ FROM bref/build-php-$PHP_VERSION:$BREF_VERSION AS ext
 ARG PHP_VERSION
 
 # Prepare environment
-ENV IMAGICK_BUILD_DIR=${BUILD_DIR}/amqp
+ENV AMQP_BUILD_DIR=${BUILD_DIR}/amqp
 RUN mkdir -p ${AMQP_BUILD_DIR}
 
 # Compile rabbitmq
@@ -26,10 +26,9 @@ RUN make install
 
 RUN cp `php-config --extension-dir`/amqp.so /tmp/amqp.so
 RUN strip --strip-debug /tmp/amqp.so
-RUN echo 'extension=imagick.so' > /tmp/ext.ini
+RUN echo 'extension=amqp.so' > /tmp/ext.ini
 
 RUN php /bref/lib-copy/copy-dependencies.php /tmp/amqp.so /tmp/extension-libs
-
 
 # Build the final image with just the files we need
 FROM scratch

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -8,8 +8,10 @@ ENV AMQP_BUILD_DIR=${BUILD_DIR}/amqp
 RUN mkdir -p ${AMQP_BUILD_DIR}
 
 # Compile rabbitmq
+WORKDIR ${AMQP_BUILD_DIR}
 RUN curl -Ls -o rabbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
 RUN tar xzf rabbitmq-c.tar.gz
+RUN ls
 WORKDIR ${AMQP_BUILD_DIR}/rabbitmq-c-0.13.0
 RUN cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
 RUN cmake --build . --target install

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -8,8 +8,8 @@ ENV AMQP_BUILD_DIR=${BUILD_DIR}/amqp
 RUN mkdir -p ${AMQP_BUILD_DIR}
 
 # Compile rabbitmq
-RUN curl -Ls -o abbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
-RUN tar xzf abbitmq-c.tar.gz
+RUN curl -Ls -o rabbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
+RUN tar xzf rabbitmq-c.tar.gz
 WORKDIR ${AMQP_BUILD_DIR}/rabbitmq-c-0.13.0
 RUN cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
 RUN cmake --build . --target install

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -3,25 +3,30 @@ ARG BREF_VERSION
 FROM bref/build-php-$PHP_VERSION:$BREF_VERSION AS ext
 ARG PHP_VERSION
 
-ENV LIBRABBITMQ_BUILD_DIR=${BUILD_DIR}/librabbitmq
+# Prepare environment
+ENV IMAGICK_BUILD_DIR=${BUILD_DIR}/amqp
+RUN mkdir -p ${AMQP_BUILD_DIR}
 
-RUN set -xe; \
-    mkdir -p ${LIBRABBITMQ_BUILD_DIR}; \
-    # Download and upack the source code
-    curl -Ls  https://github.com/alanxz/rabbitmq-c/archive/v0.9.0.tar.gz  \
-    | tar xzC ${LIBRABBITMQ_BUILD_DIR}
+# Compile rabbitmq
+RUN curl -Ls https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
+RUN tar xzC ${AMQP_BUILD_DIR}
+WORKDIR ${AMQP_BUILD_DIR}/rabbitmq-c-0.13.0
+RUN cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
+RUN cmake --build . --target install
 
-# Move into the unpackaged code directory
-WORKDIR  ${LIBRABBITMQ_BUILD_DIR}/rabbitmq-c-0.9.0/
+# Compile the php amqp extension
+WORKDIR ${AMQP_BUILD_DIR}
+RUN git clone https://github.com/php-amqp/php-amqp
+WORKDIR ${AMQP_BUILD_DIR}/amqp
+RUN git reset --hard 618e06ad2ef867598831cdd3faadba0dd65be917
+RUN phpize
+RUN ./configure
+RUN make -j $(nproc)
+RUN make install
 
-# Install
-RUN set -xe; \
-    cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} . && \
-    cmake --build . --target install
-
-RUN if [[ "$PHP_VERSION" = "80" ]] ; then pecl install amqp-1.11.0beta ; else pecl install amqp ; fi
 RUN cp `php-config --extension-dir`/amqp.so /tmp/amqp.so
-RUN echo 'extension=amqp.so' > /tmp/ext.ini
+RUN strip --strip-debug /tmp/amqp.so
+RUN echo 'extension=imagick.so' > /tmp/ext.ini
 
 RUN php /bref/lib-copy/copy-dependencies.php /tmp/amqp.so /tmp/extension-libs
 

--- a/layers/amqp/Dockerfile
+++ b/layers/amqp/Dockerfile
@@ -8,8 +8,8 @@ ENV AMQP_BUILD_DIR=${BUILD_DIR}/amqp
 RUN mkdir -p ${AMQP_BUILD_DIR}
 
 # Compile rabbitmq
-RUN curl -Ls https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
-RUN tar xzC ${AMQP_BUILD_DIR}
+RUN curl -Ls -o abbitmq-c.tar.gz https://github.com/alanxz/rabbitmq-c/archive/refs/tags/v0.13.0.tar.gz
+RUN tar xzf abbitmq-c.tar.gz
 WORKDIR ${AMQP_BUILD_DIR}/rabbitmq-c-0.13.0
 RUN cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} .
 RUN cmake --build . --target install


### PR DESCRIPTION
The most recent build failed, and on further investigation, the extension on pecl only works on PHP 8.0, not 8.1 and 8.2 - we need to build from source.