### PR TITLE
Add ddappsec.so to datadog extension

### DIFF
--- a/layers/datadog/Dockerfile
+++ b/layers/datadog/Dockerfile
@@ -15,6 +15,7 @@ RUN php datadog-setup.php --php-bin=all --enable-profiling
 
 RUN cp "$(php-config --extension-dir)/ddtrace.so" /tmp/ddtrace.so && \
     cp "$(php-config --extension-dir)/datadog-profiling.so" /tmp/datadog-profiling.so && \
+    cp "$(php-config --extension-dir)/ddappsec.so" /tmp/ddappsec.so && \
     cp "$(php-config --ini-dir)/98-ddtrace.ini" /tmp/ext.ini
 
 RUN sed -i 's/extension = ddtrace\.so/extension = \/opt\/bref-extra\/ddtrace.so/' /tmp/ext.ini && \
@@ -29,5 +30,6 @@ FROM scratch
 # Copy things we installed to the final image
 COPY --from=ext /tmp/ddtrace.so /opt/bref-extra/ddtrace.so
 COPY --from=ext /tmp/datadog-profiling.so /opt/bref-extra/datadog-profiling.so
+COPY --from=ext /tmp/ddappsec.so /opt/bref-extra/ddappsec.so
 COPY --from=ext /tmp/ext.ini /opt/bref/etc/php/conf.d/98-ddtrace.ini
 COPY --from=ext /opt/datadog/ /opt/datadog


### PR DESCRIPTION
Fixes https://github.com/brefphp/extra-php-extensions/issues/456.

Without this I'm getting the following errors:
```
Warning: PHP Startup: Unable to load dynamic library 'ddappsec.so' (tried: /opt/bref/extensions/ddappsec.so (/opt/bref/extensions/ddappsec.so: cannot open shared object file: No such file or directory), /opt/bref/extensions/ddappsec.so.so (/opt/bref/extensions/ddappsec.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
```