### PR TITLE
Update elastic to v1.8.4

### DIFF
--- a/layers/elastic-apm/Dockerfile
+++ b/layers/elastic-apm/Dockerfile
@@ -5,14 +5,15 @@ FROM bref/build-php-$PHP_VERSION:$BREF_VERSION AS ext
 RUN \
     LD_LIBRARY_PATH=/lib64:/lib yum install -y libcurl-devel openssl-devel \
     && mkdir /tmp/apm \
-    && curl -L https://github.com/elastic/apm-agent-php/archive/refs/tags/v1.8.1.tar.gz | tar -C /tmp/apm -zx --strip-components=1 \
+    && curl -L https://github.com/elastic/apm-agent-php/archive/refs/tags/v1.8.4.tar.gz | tar -C /tmp/apm -zx --strip-components=1 \
     && cd /tmp/apm/src/ext \
     && phpize \
     && CFLAGS="-std=gnu99" ./configure --enable-elastic_apm \
     && make clean \
     && make \
     && make install \
-    && echo 'extension=elastic_apm.so' > /tmp/elastic-apm.ini
+    && echo 'extension=elastic_apm.so' > /tmp/elastic-apm.ini \
+    && echo "elastic_apm.bootstrap_php_part_file=/opt/bref/etc/elastic-apm-agent-php-src/bootstrap_php_part.php" >> /tmp/elastic-apm.ini
 
 # Build the final image from the scratch image that contain files you want to export
 FROM scratch
@@ -20,3 +21,4 @@ FROM scratch
 # Copy the two key files to the correct location for the empty layer.
 COPY --from=ext /tmp/apm/src/ext/modules/elastic_apm.so /opt/bref/extensions/elastic_apm.so
 COPY --from=ext /tmp/elastic-apm.ini /opt/bref/etc/php/conf.d/elastic-apm.ini
+COPY --from=ext /tmp/apm/src/ /opt/bref/etc/elastic-apm-agent-php-src/


### PR DESCRIPTION
Elastic agent 1.8.1 is quite buggy. I've updated it to 1.8.4.
Also I've added the required src files, in order the make the implementation work. 
See https://www.elastic.co/guide/en/apm/agent/php/current/setup.html#build-from-source

With out this src files, elastic agent error out.