### PR TITLE
Use non-beta SQLSRV 5.12.0 for PHP 8.1 and later

### DIFF
--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -10,9 +10,9 @@ RUN yum -y install unixODBC-devel-2.3.1-14.amzn2.x86_64
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
 RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.1.1-1.x86_64
 
-RUN if [ "$PHP_VERSION" = "83" ]; \
-    then SQLSRV_VERSION=5.12.0beta1 ; \
-    else SQLSRV_VERSION=5.11.1 ; \
+RUN if [ "$PHP_VERSION" = "80" ]; \
+    then SQLSRV_VERSION=5.11.1 ; \
+    else SQLSRV_VERSION=5.12.0 ; \
     fi ; \
     pecl install sqlsrv-${SQLSRV_VERSION} && \
     pecl install pdo_sqlsrv-${SQLSRV_VERSION}


### PR DESCRIPTION
Microsoft released the non-beta version of `5.12.0` of SQLSRV on January 31, 2024. https://learn.microsoft.com/en-us/sql/connect/php/release-notes-php-sql-driver?view=sql-server-ver16

SQLSRV 5.12.0 drops support for PHP 8.0. This PR continues to use `5.11.1` for PHP 8.0, and upgrades 8.1, 8.2 and 8.3 to use `5.12.0`. Previously 8.3 was using `5.12.0beta1`