### PR TITLE
Upgrade NewRelic Agent to v11.3.0.16

### DIFF
--- a/layers/newrelic/Dockerfile
+++ b/layers/newrelic/Dockerfile
@@ -3,7 +3,7 @@ ARG BREF_VERSION
 FROM bref/build-php-$PHP_VERSION:$BREF_VERSION AS ext
 
 # Build the New Relic Agent - install silently
-ARG NEWRELIC_VERSION=11.0.0.13
+ARG NEWRELIC_VERSION=11.3.0.16
 RUN \
   curl -L https://download.newrelic.com/php_agent/archive/${NEWRELIC_VERSION}/newrelic-php5-${NEWRELIC_VERSION}-linux.tar.gz | tar -C /tmp -zx && \
   export NR_INSTALL_USE_CP_NOT_LN=1 && \


### PR DESCRIPTION
Release notes
https://github.com/newrelic/newrelic-php-agent/releases/tag/v11.1.0.14 
https://github.com/newrelic/newrelic-php-agent/releases/tag/v11.2.0.15 
https://github.com/newrelic/newrelic-php-agent/releases/tag/v11.3.0.16