### PR TITLE
Update datadog extension to support php 84

### DIFF
--- a/layers/datadog/Dockerfile
+++ b/layers/datadog/Dockerfile
@@ -7,7 +7,7 @@ ENV DDTRACE_BUILD_DIR=${BUILD_DIR}/ddtrace
 RUN set -xe; \
     mkdir -p ${DDTRACE_BUILD_DIR}; \
     curl -Ls -o ${DDTRACE_BUILD_DIR}/datadog-setup.php \
-      https://github.com/DataDog/dd-trace-php/releases/download/1.5.1/datadog-setup.php
+      https://github.com/DataDog/dd-trace-php/releases/download/1.10.0/datadog-setup.php
 
 WORKDIR ${DDTRACE_BUILD_DIR}
 


### PR DESCRIPTION
The layer:php-84-fpm currently causes a crash in the Datadog extension due to profiling being enabled by default.
- https://github.com/DataDog/dd-trace-php/releases/tag/1.5.1

 Since the Datadog extension in the layer is pretty outdated, this PR updates it to the latest available version to resolve the crash and benefit from the latest improvements.