### PR TITLE
v1: Upgrade Microsoft SQLSRV to 5.13.0 for PHP 8.3 and 8.4

### DIFF
--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -27,9 +27,9 @@ RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.6.1-1.x86_64
 
 RUN if [ "$PHP_VERSION" = "80" ]; \
     then SQLSRV_VERSION=5.11.1 ; \
-    elif [ "$PHP_VERSION" = "84" ]; \
-    then SQLSRV_VERSION=5.13.0beta1 ; \
-    else SQLSRV_VERSION=5.12.0 ; \
+    elif [ "$PHP_VERSION" = "81" ] || [ "$PHP_VERSION" = "82" ]; \
+    then SQLSRV_VERSION=5.12.0 ; \
+    else SQLSRV_VERSION=5.13.0 ; \
     fi ; \
     pecl install sqlsrv-${SQLSRV_VERSION} && \
     pecl install pdo_sqlsrv-${SQLSRV_VERSION}

--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -5,6 +5,21 @@ ARG PHP_VERSION
 
 ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
 
+# Workaround for openssl-snapsafe-libs conflict in AL2 Lambda base images.
+# See: https://github.com/aws/aws-lambda-base-images/issues/245#issuecomment-2714953498
+RUN cat > /etc/yum.repos.d/amzn2-extras-snapsafe.repo << 'EOF'
+[amzn2extra-openssl-snapsafe]
+name=Amazon Extras repo for openssl-snapsafe
+enabled=1
+mirrorlist=$awsproto://$amazonlinux.$awsregion.$awsdomain/2/extras/openssl-snapsafe/latest/$basearch/mirror.list
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
+priority=10
+skip_if_unavailable=1
+report_instanceid=yes
+EOF
+RUN yum upgrade -y openssl-snapsafe-libs
+
 RUN yum -y install unixODBC-devel-2.3.1-14.amzn2.x86_64
 
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo

--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -8,10 +8,13 @@ ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
 RUN yum -y install unixODBC-devel-2.3.1-14.amzn2.x86_64
 
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
-RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.1.1-1.x86_64
+# RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.1.1-1.x86_64
+RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.6.1-1.x86_64
 
 RUN if [ "$PHP_VERSION" = "80" ]; \
     then SQLSRV_VERSION=5.11.1 ; \
+    elif [ "$PHP_VERSION" = "84" ]; \
+    then SQLSRV_VERSION=5.13.0beta1 ; \
     else SQLSRV_VERSION=5.12.0 ; \
     fi ; \
     pecl install sqlsrv-${SQLSRV_VERSION} && \

--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -7,17 +7,17 @@ ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
 
 # Workaround for openssl-snapsafe-libs conflict in AL2 Lambda base images.
 # See: https://github.com/aws/aws-lambda-base-images/issues/245#issuecomment-2714953498
-RUN cat > /etc/yum.repos.d/amzn2-extras-snapsafe.repo << 'EOF'
-[amzn2extra-openssl-snapsafe]
-name=Amazon Extras repo for openssl-snapsafe
-enabled=1
-mirrorlist=$awsproto://$amazonlinux.$awsregion.$awsdomain/2/extras/openssl-snapsafe/latest/$basearch/mirror.list
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2
-priority=10
-skip_if_unavailable=1
-report_instanceid=yes
-EOF
+RUN printf '%s\n' \
+    '[amzn2extra-openssl-snapsafe]' \
+    'name=Amazon Extras repo for openssl-snapsafe' \
+    'enabled=1' \
+    'mirrorlist=$awsproto://$amazonlinux.$awsregion.$awsdomain/2/extras/openssl-snapsafe/latest/$basearch/mirror.list' \
+    'gpgcheck=1' \
+    'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2' \
+    'priority=10' \
+    'skip_if_unavailable=1' \
+    'report_instanceid=yes' \
+    > /etc/yum.repos.d/amzn2-extras-snapsafe.repo
 RUN yum upgrade -y openssl-snapsafe-libs
 
 RUN yum -y install unixODBC-devel-2.3.1-14.amzn2.x86_64

--- a/layers/sqlsrv/Dockerfile
+++ b/layers/sqlsrv/Dockerfile
@@ -8,7 +8,6 @@ ENV LD_LIBRARY_PATH=/usr/lib:/usr/lib64:$LD_LIBRARY_PATH
 RUN yum -y install unixODBC-devel-2.3.1-14.amzn2.x86_64
 
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/mssql-release.repo
-# RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.1.1-1.x86_64
 RUN ACCEPT_EULA=Y yum -y install msodbcsql17-17.10.6.1-1.x86_64
 
 RUN if [ "$PHP_VERSION" = "80" ]; \


### PR DESCRIPTION
Microsoft released SQLSRV 5.13.0 with official support for PHP 8.4 on February 27, 2026: https://github.com/microsoft/msphpsql/releases/tag/v5.13.0

The previously released version `5.12.0` did not officially support PHP 8.4. This PR makes `SQLSRV` available to Bref v2 PHP 8.4 for the first time.

This PR switches PHP 8.3 and 8.4 to use 5.13.0, while leaving 8.0 on 5.11.0 (last supported), 8.1 and 8.2 on 5.12.0 (last supported).

This PR also bumps to the latest patch release of Microsoft ODBC Driver 17 for SQL Server `17.10.6.1`.

### About the workaround for `openssl-snapsafe-libs`

AL2 Lambda base images ship `openssl-snapsafe-libs` for SnapStart, but its extras repo isn't included. When installing packages that depend on `openssl-libs` (like `msodbcsql17`), yum pulls a newer version that conflicts with the pre-installed snapsafe package. The workaround adds the missing repo and upgrades `openssl-snapsafe-libs` to a compatible version before installing the driver. This is the [AWS-recommended fix](https://github.com/aws/aws-lambda-base-images/issues/245#issuecomment-2717501840).
