### PR TITLE
Update Datadog layer to use dd-trace-php v1.20.0

### DIFF
--- a/layers/datadog/Dockerfile
+++ b/layers/datadog/Dockerfile
@@ -7,7 +7,7 @@ ENV DDTRACE_BUILD_DIR=${BUILD_DIR}/ddtrace
 RUN set -xe; \
     mkdir -p ${DDTRACE_BUILD_DIR}; \
     curl -Ls -o ${DDTRACE_BUILD_DIR}/datadog-setup.php \
-      https://github.com/DataDog/dd-trace-php/releases/download/1.16.0/datadog-setup.php
+      https://github.com/DataDog/dd-trace-php/releases/download/1.20.0/datadog-setup.php
 
 WORKDIR ${DDTRACE_BUILD_DIR}
 


### PR DESCRIPTION
Bump Datadog layer to update `dd-trace-php` to `v1.20.0` for latest bugfixes.

Layer builds and test passes on all PHP versions.
```bash
layer=datadog make test
#> ...
#> - Test passed
```