### PR TITLE
Fix typos

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ functions:
 | MaxMind DB       | `${bref-extra:maxminddb-php-81}`       |
 | Memcache         | `${bref-extra:memcache-php-81}`        |
 | Memcached        | `${bref-extra:memcached-php-81}`       |
-| MongoDB v1.x     | `${bref-extra:mongodb-php-81`          |
+| MongoDB v1.x     | `${bref-extra:mongodb-php-81}`         |
 | MongoDB v2.x     | `${bref-extra:mongodb2-php-81}`        |
 | MsgPack          | `${bref-extra:msgpack-php-81}`         |
 | Newrelic         | `${bref-extra:newrelic-php-81}`        |

--- a/docs/datadog.md
+++ b/docs/datadog.md
@@ -16,7 +16,7 @@ If you are running an ARM-based Lambda in AWS commercial regions, use the follow
 
 After installing the layer and the agent, you must configure the Datadog extension by adding the following key/value pair to a Lambda environment variable:
 
-- `DD_ENV=<enviroment>`
+- `DD_ENV=<environment>`
 - `DD_SERVICE=<service>`
 - `DD_SITE=<datadoghq.eu|datadoghq.com>` (depending on your Datadog account region)
 - `DD_API_KEY=<api_key>`

--- a/layers/memcache/Dockerfile
+++ b/layers/memcache/Dockerfile
@@ -7,7 +7,7 @@ ENV LIBMEMCACHED_BUILD_DIR=${BUILD_DIR}/libmemcached
 
 RUN set -xe; \
     mkdir -p ${LIBMEMCACHED_BUILD_DIR}; \
-    # Download and upack the source code
+    # Download and unpack the source code
     curl -Ls  https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz  \
     | tar xzC ${LIBMEMCACHED_BUILD_DIR}
 

--- a/layers/memcached/Dockerfile
+++ b/layers/memcached/Dockerfile
@@ -8,7 +8,7 @@ RUN LD_LIBRARY_PATH= dnf install -y patch
 
 RUN set -xe; \
     mkdir -p ${LIBMEMCACHED_BUILD_DIR}; \
-    # Download and upack the source code
+    # Download and unpack the source code
     curl -Ls  https://launchpad.net/libmemcached/1.0/1.0.18/+download/libmemcached-1.0.18.tar.gz  \
     | tar xzC ${LIBMEMCACHED_BUILD_DIR}
 

--- a/layers/newrelic/Dockerfile
+++ b/layers/newrelic/Dockerfile
@@ -12,7 +12,7 @@ RUN \
   rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
 
 # newrelic.so will be installed to `php-config --extension-dir`/newrelic.so
-# In this core image newrelic.ini will be placed but not exist in the scatch layer
+# In this core image newrelic.ini will be placed but not exist in the scratch layer
 # ${INSTALL_DIR}/etc/php/php.ini /tmp/php.ini - php.ini will contain the needed config and extension ref
 
 # Copy the newrelic.so and php.ini file to the tmp folder

--- a/layers/rdkafka/Dockerfile
+++ b/layers/rdkafka/Dockerfile
@@ -6,7 +6,7 @@ ENV LIBRDKAFKA_BUILD_DIR=${BUILD_DIR}/librdkafka
 
 RUN set -xe; \
     mkdir -p ${LIBRDKAFKA_BUILD_DIR}; \
-    # Download and upack the source code
+    # Download and unpack the source code
     curl -Ls  https://github.com/edenhill/librdkafka/archive/refs/tags/v1.8.2.tar.gz   \
     | tar xzC ${LIBRDKAFKA_BUILD_DIR}
 

--- a/layers/yaml/Dockerfile
+++ b/layers/yaml/Dockerfile
@@ -6,7 +6,7 @@ ENV LIBYAML_BUILD_DIR=${BUILD_DIR}/libyaml
 
 RUN set -xe; \
     mkdir -p ${LIBYAML_BUILD_DIR}; \
-    # Download and upack the source code
+    # Download and unpack the source code
     curl -Ls https://github.com/yaml/libyaml/archive/0.2.5.tar.gz  \
     | tar xzC ${LIBYAML_BUILD_DIR}
 


### PR DESCRIPTION
## Summary

- correct spelling errors reported by `typos` in Dockerfile comments and Datadog documentation

using https://github.com/crate-ci/typos and a 🤖